### PR TITLE
client: add RemoveAllInstances

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -500,3 +500,123 @@ func TestListInstances(t *testing.T) {
 		assert.Equal(t, opts.Filter, fmt.Sprintf(`{"tags":"%s=1234"}`, client.TagPool))
 	})
 }
+
+func TestRemoveAllInstances(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		m := &mockLinode{
+			calls: []call{},
+			listInstances: func(ctx context.Context, opts *linodego.ListOptions) ([]linodego.Instance, error) {
+				return []linodego.Instance{
+					{
+						ID: 1111,
+					},
+					{
+						ID: 2222,
+					},
+				}, nil
+			},
+		}
+
+		cli, err := client.New(
+			&config.Config{
+				Token: "foo",
+			},
+			m,
+			"1234",
+		)
+		require.NoError(t, err)
+
+		err = cli.RemoveAllInstances(t.Context())
+		require.NoError(t, err)
+
+		require.Len(t, m.calls, 3)
+		c := m.calls[0]
+		assert.Equal(t, c.name, MockListInstances)
+
+		opts, ok := c.args.(*linodego.ListOptions)
+		require.True(t, ok)
+		assert.Equal(t, opts.Filter, `{"tags":"garm-controller-id=1234"}`)
+
+		c = m.calls[1]
+		assert.Equal(t, c.name, MockDeleteInstance)
+
+		id, ok := c.args.(int)
+		require.True(t, ok)
+		assert.Equal(t, id, 1111)
+
+		c = m.calls[2]
+		assert.Equal(t, c.name, MockDeleteInstance)
+
+		id, ok = c.args.(int)
+		require.True(t, ok)
+		assert.Equal(t, id, 2222)
+	})
+
+	t.Run("Fail to list instances", func(t *testing.T) {
+		m := &mockLinode{
+			calls: []call{},
+			listInstances: func(ctx context.Context, opts *linodego.ListOptions) ([]linodego.Instance, error) {
+				return nil, fmt.Errorf("random error from the API")
+			},
+		}
+
+		cli, err := client.New(
+			&config.Config{
+				Token: "foo",
+			},
+			m,
+			"1234",
+		)
+		require.NoError(t, err)
+
+		err = cli.RemoveAllInstances(t.Context())
+		assert.ErrorContains(t, err, "getting instances list from Linode API: random error from the API")
+
+		require.Len(t, m.calls, 1)
+		c := m.calls[0]
+		assert.Equal(t, c.name, MockListInstances)
+	})
+
+	t.Run("Fail to delete one instance", func(t *testing.T) {
+		m := &mockLinode{
+			calls: []call{},
+			deleteInstance: func(ctx context.Context, ID int) error {
+				return fmt.Errorf("random error from the API")
+			},
+			listInstances: func(ctx context.Context, opts *linodego.ListOptions) ([]linodego.Instance, error) {
+				return []linodego.Instance{
+					{
+						ID: 1111,
+					},
+				}, nil
+			},
+		}
+
+		cli, err := client.New(
+			&config.Config{
+				Token: "foo",
+			},
+			m,
+			"1234",
+		)
+		require.NoError(t, err)
+
+		err = cli.RemoveAllInstances(t.Context())
+		assert.ErrorContains(t, err, "deleting instance 1111: deleting instance from Linode API: random error from the API")
+
+		require.Len(t, m.calls, 2)
+		c := m.calls[0]
+		assert.Equal(t, c.name, MockListInstances)
+
+		opts, ok := c.args.(*linodego.ListOptions)
+		require.True(t, ok)
+		assert.Equal(t, opts.Filter, `{"tags":"garm-controller-id=1234"}`)
+
+		c = m.calls[1]
+		assert.Equal(t, c.name, MockDeleteInstance)
+
+		id, ok := c.args.(int)
+		require.True(t, ok)
+		assert.Equal(t, id, 1111)
+	})
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -103,7 +103,10 @@ func (p *linodeProvider) ListInstances(ctx context.Context, poolID string) ([]pa
 
 // RemoveAllInstances will remove all instances created by this provider.
 func (p *linodeProvider) RemoveAllInstances(ctx context.Context) error {
-	// TODO: Implements p.cli.RemoveAllInstances(ctx).
+	if err := p.cli.RemoveAllInstances(ctx); err != nil {
+		return fmt.Errorf("removing all instances: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This is not used by Garm yet but has to be implemented.

---

In this PR, we implement `RemoveAllInstances` method. This is not yet used by Garm, but it has to be implemented according to the documentation: https://github.com/cloudbase/garm/blob/main/doc/external_provider.md#removeallinstances

Related to: https://github.com/flatcar/garm-provider-linode/issues/1