### PR TITLE
Update garm-provider-common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/BurntSushi/toml v1.5.0
-	github.com/cloudbase/garm-provider-common v0.1.5
+	github.com/cloudbase/garm-provider-common v0.1.6
 	github.com/linode/linodego v1.53.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/oauth2 v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/cloudbase/garm-provider-common v0.1.5 h1:aJL646l+VnZceQ2grbDYhWfxYpaQR2/QsUSD76kSZVs=
-github.com/cloudbase/garm-provider-common v0.1.5/go.mod h1:2O51WbcfqRx5fDHyyJgIFq7KdTZZnefsM+aoOchyleU=
+github.com/cloudbase/garm-provider-common v0.1.6 h1:wLqolRkUD2Z4rzuBLDs2exL1Aq+eJ5RBVnRvk5JP6fs=
+github.com/cloudbase/garm-provider-common v0.1.6/go.mod h1:2O51WbcfqRx5fDHyyJgIFq7KdTZZnefsM+aoOchyleU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,7 +2,7 @@
 ## explicit; go 1.18
 github.com/BurntSushi/toml
 github.com/BurntSushi/toml/internal
-# github.com/cloudbase/garm-provider-common v0.1.5
+# github.com/cloudbase/garm-provider-common v0.1.6
 ## explicit; go 1.23.0
 github.com/cloudbase/garm-provider-common/cloudconfig
 github.com/cloudbase/garm-provider-common/defaults


### PR DESCRIPTION
# Update garm-provider-common to v0.1.6

This version of garm-provider-common contains a fix for Windows userdata which now creates a dedicated user under which the github runner is started as a service. This new user has SeLoginRight and is part of the local Administrators group. Some applications and workflows require an actual user with a proper user profile. This change should allow any workflow to function properly on Windows.

## How to use

Simply rebuild.